### PR TITLE
ci: change macOS x86_64 runner to macos-13

### DIFF
--- a/.github/workflows/maturin.yml
+++ b/.github/workflows/maturin.yml
@@ -111,7 +111,7 @@ jobs:
       fail-fast: false
       matrix:
         platform:
-          - runner: macos-latest
+          - runner: macos-13
             target: x86_64
           - runner: macos-14
             target: aarch64


### PR DESCRIPTION
Apparently macos-latest now runs in an arm64 mac.