### PR TITLE
Update sphinx dependencies

### DIFF
--- a/sphinx/requirements.txt
+++ b/sphinx/requirements.txt
@@ -32,15 +32,15 @@ idna==3.10
     # via requests
 imagesize==1.4.1
     # via sphinx
-jinja2==3.1.5
+jinja2==3.1.6
     # via sphinx
 kiwisolver==1.4.8
     # via matplotlib
 markupsafe==3.0.2
     # via jinja2
-matplotlib==3.10.0
+matplotlib==3.10.1
     # via -r requirements.in
-numpy==2.2.2
+numpy==2.2.4
     # via
     #   -r requirements.in
     #   contourpy
@@ -67,7 +67,9 @@ python-dateutil==2.9.0.post0
     # via matplotlib
 requests==2.32.3
     # via sphinx
-scipy==1.15.1
+roman-numerals-py==3.1.0
+    # via sphinx
+scipy==1.15.2
     # via -r requirements.in
 six==1.17.0
     # via python-dateutil
@@ -75,7 +77,7 @@ snowballstemmer==2.2.0
     # via sphinx
 soupsieve==2.6
     # via beautifulsoup4
-sphinx==8.1.3
+sphinx==8.2.3
     # via
     #   -r requirements.in
     #   numpydoc


### PR DESCRIPTION
This updates the sphinx dependencies with 'pip-compile -U' to fix a security advisory for Jinja2.