### PR TITLE
Update sphinx requirements.txt

### DIFF
--- a/sphinx/requirements.txt
+++ b/sphinx/requirements.txt
@@ -12,13 +12,13 @@ babel==2.17.0
     # via
     #   pydata-sphinx-theme
     #   sphinx
-beautifulsoup4==4.13.3
+beautifulsoup4==4.13.4
     # via pydata-sphinx-theme
-certifi==2025.1.31
+certifi==2025.7.14
     # via requests
-charset-normalizer==3.4.1
+charset-normalizer==3.4.2
     # via requests
-contourpy==1.3.1
+contourpy==1.3.2
     # via matplotlib
 cycler==0.12.1
     # via matplotlib
@@ -26,7 +26,7 @@ docutils==0.21.2
     # via
     #   pydata-sphinx-theme
     #   sphinx
-fonttools==4.56.0
+fonttools==4.58.5
     # via matplotlib
 idna==3.10
     # via requests
@@ -38,44 +38,44 @@ kiwisolver==1.4.8
     # via matplotlib
 markupsafe==3.0.2
     # via jinja2
-matplotlib==3.10.1
+matplotlib==3.10.3
     # via -r requirements.in
-numpy==2.2.4
+numpy==2.3.1
     # via
     #   -r requirements.in
     #   contourpy
     #   matplotlib
     #   scipy
-numpydoc==1.8.0
+numpydoc==1.9.0
     # via -r requirements.in
-packaging==24.2
+packaging==25.0
     # via
     #   matplotlib
     #   sphinx
-pillow==11.1.0
+pillow==11.3.0
     # via matplotlib
 pydata-sphinx-theme==0.16.1
     # via -r requirements.in
-pygments==2.19.1
+pygments==2.19.2
     # via
     #   accessible-pygments
     #   pydata-sphinx-theme
     #   sphinx
-pyparsing==3.2.1
+pyparsing==3.2.3
     # via matplotlib
 python-dateutil==2.9.0.post0
     # via matplotlib
-requests==2.32.3
+requests==2.32.4
     # via sphinx
 roman-numerals-py==3.1.0
     # via sphinx
-scipy==1.15.2
+scipy==1.16.0
     # via -r requirements.in
 six==1.17.0
     # via python-dateutil
-snowballstemmer==2.2.0
+snowballstemmer==3.0.1
     # via sphinx
-soupsieve==2.6
+soupsieve==2.7
     # via beautifulsoup4
 sphinx==8.2.3
     # via
@@ -94,11 +94,9 @@ sphinxcontrib-qthelp==2.0.0
     # via sphinx
 sphinxcontrib-serializinghtml==2.0.0
     # via sphinx
-tabulate==0.9.0
-    # via numpydoc
-typing-extensions==4.12.2
+typing-extensions==4.14.1
     # via
     #   beautifulsoup4
     #   pydata-sphinx-theme
-urllib3==2.3.0
+urllib3==2.5.0
     # via requests


### PR DESCRIPTION
Bump dependencies in sphinx requirements.txt using pip-compile in order to fix security advisories in urllib3 and requests.